### PR TITLE
make short Korean Message in Pref Screen

### DIFF
--- a/1.0.13/Korean.lproj/Pref.xib
+++ b/1.0.13/Korean.lproj/Pref.xib
@@ -245,7 +245,7 @@
 										<object class="NSTextFieldCell" key="NSCell" id="569483789">
 											<int key="NSCellFlags">68288064</int>
 											<int key="NSCellFlags2">272630784</int>
-											<string key="NSContents">저절로 안보일 때까지 시간</string>
+											<string key="NSContents">저절로 사라지는 시간</string>
 											<reference key="NSSupport" ref="472449914"/>
 											<reference key="NSControlView" ref="252110283"/>
 											<object class="NSColor" key="NSBackgroundColor" id="592303529">
@@ -696,7 +696,7 @@
 										<object class="NSTextFieldCell" key="NSCell" id="639616776">
 											<int key="NSCellFlags">68288064</int>
 											<int key="NSCellFlags2">272630784</int>
-											<string key="NSContents">저절로 안보일 때까지 시간</string>
+											<string key="NSContents">저절로 사라지는 시간</string>
 											<reference key="NSSupport" ref="472449914"/>
 											<reference key="NSControlView" ref="881927557"/>
 											<reference key="NSBackgroundColor" ref="592303529"/>


### PR DESCRIPTION
When Using Korean Font -Apple Gothic, message is too long so hide some characters in preference pane.
made short the msg.
Apple Gothic フォントで設定画面の一部メッセージの最後の文字が見えなくなるのでメッセージを短く修正。
애플 고딕폰트 사용시 설정화면의 일부 문자가 짤리므로, 메시지를 짧게 고쳤음.
